### PR TITLE
Make tests pass, fix typo, optimize a bit.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,7 @@ func NewHandler(server *Server) *Handler {
 }
 
 func (handler *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
-	backendNames := handler.server.onSelecBackendtHandler(req)
+	backendNames := handler.server.onSelectBackendHandler(req)
 	backendCount := len(backendNames)
 
 	masterResponseCh := make(chan *Response, 1)
@@ -39,7 +39,7 @@ func (handler *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 			requestCount = requestCount + 1
 			responses[response.Backend.Name] = response
 
-			if requestCount >= len(backendNames) {
+			if requestCount >= backendCount {
 				if handler.server.onBackendFinishedHandler != nil {
 					handler.server.onBackendFinishedHandler(responses)
 				}

--- a/server.go
+++ b/server.go
@@ -14,7 +14,7 @@ type Server struct {
 	Port     int
 	Backends map[string]*Backend
 
-	onSelecBackendtHandler   func(req *http.Request) []string
+	onSelectBackendHandler   func(req *http.Request) []string
 	onMungeHeaderHandler     func(backend string, header *http.Header)
 	onBackendFinishedHandler func(map[string]*Response)
 }
@@ -59,7 +59,7 @@ func (server *Server) AddBackend(name, host string, port int) {
 }
 
 func (server *Server) OnSelectBackend(handler func(req *http.Request) []string) {
-	server.onSelecBackendtHandler = handler
+	server.onSelectBackendHandler = handler
 }
 
 func (server *Server) OnMungeHeader(handler func(backend string, header *http.Header)) {

--- a/server_test.go
+++ b/server_test.go
@@ -19,7 +19,7 @@ func TestServer(t *testing.T) {
 		})
 
 		It("should set a handler to select backend by default", func() {
-			Expect(server.onSelecBackendtHandler).To(Exist)
+			Expect(server.onSelectBackendHandler).To(Exist)
 		})
 	})
 
@@ -50,11 +50,11 @@ func TestServer(t *testing.T) {
 	Describe(t, "OnSelectBackend", func() {
 		server := NewServer("0.0.0.0", 8484)
 
-		It("should set a handler into its onSelecBackendtHandler field", func() {
+		It("should set a handler into its onSelectBackendHandler field", func() {
 			server.OnSelectBackend(func(req *http.Request) []string {
 				return []string{"testing"}
 			})
-			Expect(server.onSelecBackendtHandler).To(NotEqual, nil)
+			Expect(server.onSelectBackendHandler).To(NotEqual, nil)
 		})
 	})
 


### PR DESCRIPTION
Use already-computed backend count
In tests, use less likely port numbers
In tests, wait for all backends to finish
