### PR TITLE
Implement to use X-Forwarded-* header

### DIFF
--- a/examples/proxy.go
+++ b/examples/proxy.go
@@ -1,9 +1,10 @@
 package main
 
 import (
-	"../"
+	".."
 	"log"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -21,9 +22,10 @@ func main() {
 		}
 	})
 
-	server.OnMungeHeader(func(backend string, header *http.Header) {
+	server.OnMungeHeader(func(backend string, header *http.Header, req *http.Request) {
 		if backend == "testing" {
 			header.Add("X-Delta-Sandbox", "1")
+			header.Add("X-Forwarded-Host", strings.Split(req.Host, ":")[0])
 		}
 	})
 

--- a/handler.go
+++ b/handler.go
@@ -131,7 +131,7 @@ func (handler *Handler) copyRequest(backend *Backend, req *http.Request, body io
 	}
 
 	if handler.server.onMungeHeaderHandler != nil {
-		handler.server.onMungeHeaderHandler(backend.Name, &proxyRequest.Header)
+		handler.server.onMungeHeaderHandler(backend.Name, &proxyRequest.Header, req)
 	}
 
 	return proxyRequest

--- a/handler_test.go
+++ b/handler_test.go
@@ -23,7 +23,7 @@ func setupServer() *Server {
 		}
 	})
 
-	server.OnMungeHeader(func(backend string, header *http.Header) {
+	server.OnMungeHeader(func(backend string, header *http.Header, req *http.Request) {
 		if backend == "testing" {
 			header.Add("X-Delta-Sandbox", "1")
 		}

--- a/request_body_test.go
+++ b/request_body_test.go
@@ -36,7 +36,7 @@ func TestRequestBody(t *testing.T) {
 			return []string{"production"}
 		}
 	})
-	server.OnMungeHeader(func(backend string, header *http.Header) {
+	server.OnMungeHeader(func(backend string, header *http.Header, req *http.Request) {
 		header.Add("Delta-Backend", backend)
 	})
 

--- a/server.go
+++ b/server.go
@@ -15,7 +15,7 @@ type Server struct {
 	Backends map[string]*Backend
 
 	onSelectBackendHandler   func(req *http.Request) []string
-	onMungeHeaderHandler     func(backend string, header *http.Header)
+	onMungeHeaderHandler     func(backend string, header *http.Header, req *http.Request)
 	onBackendFinishedHandler func(map[string]*Response)
 }
 
@@ -62,7 +62,7 @@ func (server *Server) OnSelectBackend(handler func(req *http.Request) []string) 
 	server.onSelectBackendHandler = handler
 }
 
-func (server *Server) OnMungeHeader(handler func(backend string, header *http.Header)) {
+func (server *Server) OnMungeHeader(handler func(backend string, header *http.Header, req *http.Request)) {
 	server.onMungeHeaderHandler = handler
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -62,7 +62,7 @@ func TestServer(t *testing.T) {
 		server := NewServer("0.0.0.0", 8484)
 
 		It("should set a handler into its onMungeHeaderHandler field", func() {
-			server.OnMungeHeader(func(backend string, header *http.Header) {})
+			server.OnMungeHeader(func(backend string, header *http.Header, req *http.Request) {})
 			Expect(server.onMungeHeaderHandler).To(Exist)
 		})
 	})


### PR DESCRIPTION
specifi a real request.

```
    X-Forwarded-For gives the address of the client which connected to the proxy
    X-Forwarded-Port gives the port the client connected to on the proxy (e.g. 80 or 443)
    X-Forwarded-Proto gives the protocol the client used to connect to the proxy (http or https)
    X-Forwarded-Host gives the content of the Host header the client sent to the proxy.
```

see: http://stackoverflow.com/questions/19084340/real-life-usage-of-the-x-forwarded-host-header
