### PR TITLE
Improve memory management using pooled *bytes.Buffer & free them earlier

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,3 +1,0 @@
-gom "github.com/r7kamura/gospel"
-gom "github.com/r7kamura/router"
-

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/kentaro/delta
+
+go 1.17
+
+require (
+	github.com/r7kamura/gospel v0.0.0-20191008082110-82b9a6c1387d
+	github.com/r7kamura/router v0.0.0-20131013044821-aba3e516098d
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+)

--- a/handler.go
+++ b/handler.go
@@ -5,16 +5,26 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
+	"sync"
 	"time"
 )
 
 type Handler struct {
-	server *Server
+	server                *Server
+	bufferPool            *sync.Pool
+	maxPooledBufferLength int
 }
 
 func NewHandler(server *Server) *Handler {
 	return &Handler{
-		server: server,
+		server:                server,
+		maxPooledBufferLength: 10 * 1024 * 1024,
+		bufferPool: &sync.Pool{
+			New: func() interface{} {
+				return new(bytes.Buffer)
+			},
+		},
 	}
 }
 
@@ -27,14 +37,20 @@ func (handler *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 	done := make(chan bool)
 
 	bodies := make(map[string]io.Reader)
+	defer handler.dismissAll(bodies)
 	if req.Body != nil {
+		bodySize, hasSize := contentLength(req)
 		writers := make([]io.Writer, len(backendNames))
 		for i, name := range backendNames {
-			b := new(bytes.Buffer)
+			b := handler.bufferPool.Get().(*bytes.Buffer)
+			if hasSize {
+				// Ensure buffer size to avoid unnecessary buffer growths
+				b.Grow(bodySize)
+			}
 			writers[i] = b
 			bodies[name] = b
 		}
-		io.Copy(io.MultiWriter(writers...), req.Body)
+		_, _ = io.Copy(io.MultiWriter(writers...), req.Body)
 	}
 
 	for _, name := range backendNames {
@@ -49,10 +65,16 @@ func (handler *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 
 		for {
 			response := <-responseCh
+			backendName := response.Backend.Name
+			body := bodies[backendName]
+			// remove reference in case we won't reuse this buffer.
+			delete(bodies, backendName)
+			// dismiss buffer back to the pool early to save some allocations.
+			handler.dismiss(body)
 
 			requestCount = requestCount + 1
 			if response != nil {
-				responses[response.Backend.Name] = response
+				responses[backendName] = response
 			}
 
 			if requestCount >= backendCount {
@@ -85,6 +107,16 @@ func (handler *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request)
 	}
 
 	<-done
+}
+
+func (handler *Handler) dismiss(r io.Reader) {
+	if v, ok := r.(*bytes.Buffer); ok {
+		// We don't want to reuse huge buffers
+		if v.Len() < handler.maxPooledBufferLength {
+			v.Reset()
+			handler.bufferPool.Put(v)
+		}
+	}
 }
 
 func (handler *Handler) dispatchProxyRequest(backend *Backend, req *http.Request, body io.Reader, masterResponseCh chan *Response, responseCh chan *Response) {
@@ -135,4 +167,24 @@ func (handler *Handler) copyRequest(backend *Backend, req *http.Request, body io
 	}
 
 	return proxyRequest
+}
+
+func (handler *Handler) dismissAll(bodies map[string]io.Reader) {
+	for _, b := range bodies {
+		handler.dismiss(b)
+	}
+}
+
+func contentLength(req *http.Request) (int, bool) {
+	s := req.Header.Get("Content-Length")
+	if s == "" {
+		return 0, false
+	}
+
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+
+	return int(i), true
 }

--- a/response.go
+++ b/response.go
@@ -11,6 +11,7 @@ type Response struct {
 	HttpResponse *http.Response
 	Data         []byte
 	Elapsed      time.Duration
+	Err          error
 }
 
 func NewResponse(backend *Backend, httpResponse *http.Response, elapsed time.Duration) (response *Response, err error) {
@@ -23,8 +24,16 @@ func NewResponse(backend *Backend, httpResponse *http.Response, elapsed time.Dur
 
 	var data []byte
 	data, err = ioutil.ReadAll(httpResponse.Body)
-	response.HttpResponse.Body.Close()
+	_ = response.HttpResponse.Body.Close()
 	response.Data = data
 
 	return response, err
+}
+
+func NewErrorResponse(backend *Backend, err error, elapsed time.Duration) *Response {
+	return &Response{
+		Backend: backend,
+		Err:     err,
+		Elapsed: elapsed,
+	}
 }


### PR DESCRIPTION
This improves memory usage, especially under load when one of the backends is slow(ish)